### PR TITLE
Fix audio/subtitle menu

### DIFF
--- a/make.py
+++ b/make.py
@@ -13,6 +13,7 @@ INCLUDE_FILES = [
     "content_script.js",
     "manifest.json",
     "netflix_max_bitrate.js",
+    "style_fix.css",
     "LICENSE",
 ]
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
       "*://www.netflix.com/*"
     ],
     "all_frames": true,
+    "css": ["style_fix.css"],
     "js": ["content_script.js"],
     "run_at": "document_start"
   }],

--- a/style_fix.css
+++ b/style_fix.css
@@ -1,0 +1,3 @@
+.watch-video--selector-audio-subtitle {
+	overflow: auto;
+}


### PR DESCRIPTION
Because of the additional audio tracks the audio selection menu only shows the top possibilities, as it still thinks there are only a handful. See the "inconsistent audio tracks" comment at #28 for an example.
This fixes the menu by allowing a scrollbar via css.