### PR TITLE
Update playercore URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,8 @@
   },
   "content_scripts": [{
     "matches": [
-      "*://assets.nflxext.com/*/ffe/player/html/*",
-      "*://www.assets.nflxext.com/*/ffe/player/html/*",
-      "*://*.a.nflxso.net/sec/*/ffe/player/html/*",
+      "*://assets.nflxext.com/player/html/ffe/*",
+      "*://*.a.nflxso.net/sec/player/html/ffe/*",
       "*://netflix.com/*",
       "*://www.netflix.com/*"
     ],
@@ -42,9 +41,8 @@
     "declarativeNetRequest"
   ],
   "host_permissions": [
-    "*://assets.nflxext.com/*/ffe/player/html/*",
-    "*://www.assets.nflxext.com/*/ffe/player/html/*",
-    "*://*.a.nflxso.net/sec/*/ffe/player/html/*",
+    "*://assets.nflxext.com/player/html/ffe/*",
+    "*://*.a.nflxso.net/sec/player/html/ffe/*",
     "*://netflix.com/*",
     "*://www.netflix.com/*"
   ],

--- a/redirect_rules.json
+++ b/redirect_rules.json
@@ -7,7 +7,7 @@
             "redirect": { "extensionPath": "/cadmium-playercore-6.0044.268.911-patched.js" }
         },
         "condition": {
-            "urlFilter": "*://assets.nflxext.com/*/ffe/player/html/*"
+            "urlFilter": "*://assets.nflxext.com/player/html/ffe/*"
         }
     },
     {
@@ -18,18 +18,7 @@
             "redirect": { "extensionPath": "/cadmium-playercore-6.0044.268.911-patched.js" }
         },
         "condition": {
-            "urlFilter": "*://www.assets.nflxext.com/*/ffe/player/html/*"
-        }
-    },
-    {
-        "id": 3,
-        "priority": 1,
-        "action": {
-            "type": "redirect",
-            "redirect": { "extensionPath": "/cadmium-playercore-6.0044.268.911-patched.js" }
-        },
-        "condition": {
-            "urlFilter": "*://*.a.nflxso.net/sec/*/ffe/player/html/*"
+            "urlFilter": "*://*.a.nflxso.net/sec/player/html/ffe/*"
         }
     }
 ]


### PR DESCRIPTION
The playercore assets have been moved to the following new URLs:

https://assets.nflxext.com/player/html/ffe/cadmium-playercore-6.0045.605.911.js
https://occ-weba-h2.a.nflxso.net/sec/player/html/ffe/cadmium-playercore-6.0045.605.911.js

Since www.assets.nflxext.com no longer exists, remove this entry
while we are at it.
